### PR TITLE
Remove unused NumPy import

### DIFF
--- a/crud_mp/create_materia_prima.py
+++ b/crud_mp/create_materia_prima.py
@@ -7,7 +7,6 @@
 
 
 import streamlit as st
-import numpy as np
 from utils.supabase_client import supabase
 
 def crear_materia_prima():


### PR DESCRIPTION
## Summary
- cleanup: drop unused numpy import from materia prima creator
- run `flake8` to verify unused imports are gone

## Testing
- `flake8 crud_mp/create_materia_prima.py`

------
https://chatgpt.com/codex/tasks/task_b_686cb95d06f08333949127c6d37076b2