### PR TITLE
Add formula CRUD modules and navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,10 +15,92 @@ from utils.families import obtener_familias_parametros
 from crud_mp.create_materia_prima import crear_materia_prima
 from crud_mp.update_materia_prima import actualizar_materia_prima
 from crud_mp.delete_materia_prima import eliminar_materia_prima
+from crud_formulas.list_formulas import listar_formulas
+from crud_formulas.update_formula import actualizar_formula
+from crud_formulas.delete_formula import eliminar_formula
 from utils.guardar_formula import guardar_formula
 from utils.generar_qr import generar_qr
 from utils.formula_resultados import calcular_resultado_formula
 from utils.cargar_formula import cargar_formula_por_id
+
+
+def flujo_crear_formula():
+    """Interfaz para crear y guardar nuevas fórmulas."""
+    response = supabase.table("materias_primas").select("*").execute()
+    df = pd.DataFrame(response.data)
+    df["%"] = 0.0
+
+    if "Materia Prima" not in df.columns:
+        st.error("La columna 'Materia Prima' no está disponible en los datos.")
+        return
+
+    seleccionadas = st.multiselect(
+        "Busca y selecciona las materias primas",
+        options=df["Materia Prima"].dropna().tolist(),
+        help="Puedes escribir para buscar por nombre",
+        key="mp_crear",
+    )
+
+    if not seleccionadas:
+        st.info("Selecciona materias primas desde el buscador para comenzar.")
+        return
+
+    st.subheader("🧪 Fórmula editable")
+    df_editado, total_pct = mostrar_editor_formula(df, seleccionadas)
+
+    if df_editado is None:
+        return
+
+    filtrar_ceros = st.checkbox("Mostrar solo parámetros con cantidad > 0%", value=True)
+
+    familias = obtener_familias_parametros()
+    seleccionadas_familias = st.multiselect(
+        "Selecciona familias",
+        list(familias),
+        default=list(familias),
+        key="familias_crear",
+    )
+    columnas = [col for fam in seleccionadas_familias for col in familias[fam]]
+
+    if filtrar_ceros:
+        columnas_filtradas = [
+            col
+            for col in columnas
+            if col in df_editado.columns and (df_editado[col] * df_editado["%"] / 100).sum() > 0
+        ]
+    else:
+        columnas_filtradas = columnas
+
+    if abs(total_pct - 100) > 0.01:
+        st.warning("⚠️ La suma de los porcentajes debe ser 100% para calcular.")
+        forzar = st.checkbox(
+            "🧪 Calcular de todos modos (forzar cálculo)",
+            help="Activa esta opción si deseas calcular aunque la fórmula no sume exactamente 100%.",
+            key="forzar_crear",
+        )
+        if forzar:
+            st.info("Cálculo realizado con fórmula incompleta. Revisa los resultados con precaución.")
+            mostrar_resultados(df_editado, columnas_filtradas)
+    else:
+        mostrar_resultados(df_editado, columnas_filtradas)
+
+        st.markdown("---")
+        st.subheader("📂 Guardar fórmula")
+
+        nombre_formula = st.text_input("Nombre de la fórmula", placeholder="Ej. Bioestimulante Algas v1", key="nombre_crear")
+        if st.button("Guardar fórmula"):
+            if not nombre_formula.strip():
+                st.warning("Debes ingresar un nombre para guardar la fórmula.")
+            else:
+                precio, _ = calcular_resultado_formula(df_editado, columnas_filtradas)
+                formula_id = guardar_formula(df_editado, nombre_formula.strip(), precio)
+                url_formula = f"https://formulator-pruebas2.streamlit.app/?formula_id={formula_id}"
+                qr_img = generar_qr(url_formula)
+
+                st.success("✅ Fórmula guardada correctamente.")
+                st.image(qr_img, caption="Código QR para esta fórmula", use_container_width=False)
+                st.code(url_formula, language="markdown")
+
 
 def main():
     st.set_page_config(layout="wide")
@@ -39,7 +121,7 @@ def main():
         """, unsafe_allow_html=True)
 
         st.markdown("### Navegación")
-        menu = st.radio("Navegación", ["Formular", "Materias Primas"], label_visibility="collapsed")
+        menu = st.radio("Navegación", ["Formular", "Formulas", "Materias Primas"], label_visibility="collapsed")
 
         st.markdown("---")
         st.markdown("""
@@ -59,72 +141,24 @@ def main():
             eliminar_materia_prima()
         return
 
-    # FORMULATE
-    response = supabase.table("materias_primas").select("*").execute()
-    df = pd.DataFrame(response.data)
-    df["%"] = 0.0
+    if menu == "Formulas":
+        subtarea = st.selectbox("Acción sobre fórmulas", ["Crear", "Actualizar", "Eliminar", "Ver"])
 
-    if "Materia Prima" not in df.columns:
-        st.error("La columna 'Materia Prima' no está disponible en los datos.")
+        if subtarea == "Crear":
+            flujo_crear_formula()
+        elif subtarea == "Actualizar":
+            formula_id = listar_formulas(seleccionar=True)
+            actualizar_formula(formula_id)
+        elif subtarea == "Eliminar":
+            eliminar_formula()
+        elif subtarea == "Ver":
+            formula_id = listar_formulas(seleccionar=True)
+            if formula_id:
+                cargar_formula_por_id(formula_id)
         return
 
-    seleccionadas = st.multiselect(
-        "Busca y selecciona las materias primas",
-        options=df["Materia Prima"].dropna().tolist(),
-        help="Puedes escribir para buscar por nombre"
-    )
-
-    if not seleccionadas:
-        st.info("Selecciona materias primas desde el buscador para comenzar.")
-        return
-
-    st.subheader("🧪 Fórmula editable")
-    df_editado, total_pct = mostrar_editor_formula(df, seleccionadas)
-
-    if df_editado is not None:
-        filtrar_ceros = st.checkbox("Mostrar solo parámetros con cantidad > 0%", value=True)
-
-        familias = obtener_familias_parametros()
-        seleccionadas_familias = st.multiselect("Selecciona familias", list(familias), default=list(familias))
-        columnas = [col for fam in seleccionadas_familias for col in familias[fam]]
-
-        if filtrar_ceros:
-            columnas_filtradas = [
-                col for col in columnas
-                if col in df_editado.columns and (df_editado[col] * df_editado["%"] / 100).sum() > 0
-            ]
-        else:
-            columnas_filtradas = columnas
-
-        if abs(total_pct - 100) > 0.01:
-            st.warning("⚠️ La suma de los porcentajes debe ser 100% para calcular.")
-            forzar = st.checkbox(
-                "🧪 Calcular de todos modos (forzar cálculo)",
-                help="Activa esta opción si deseas calcular aunque la fórmula no sume exactamente 100%."
-            )
-            if forzar:
-                st.info("Cálculo realizado con fórmula incompleta. Revisa los resultados con precaución.")
-                mostrar_resultados(df_editado, columnas_filtradas)
-        else:
-            mostrar_resultados(df_editado, columnas_filtradas)
-
-            # Guardar y generar QR
-            st.markdown("---")
-            st.subheader("📂 Guardar fórmula")
-
-            nombre_formula = st.text_input("Nombre de la fórmula", placeholder="Ej. Bioestimulante Algas v1")
-            if st.button("Guardar fórmula"):
-                if not nombre_formula.strip():
-                    st.warning("Debes ingresar un nombre para guardar la fórmula.")
-                else:
-                    precio, _ = calcular_resultado_formula(df_editado, columnas_filtradas)
-                    formula_id = guardar_formula(df_editado, nombre_formula.strip(), precio)
-                    url_formula = f"https://formulator-pruebas2.streamlit.app/?formula_id={formula_id}"
-                    qr_img = generar_qr(url_formula)
-
-                    st.success("✅ Fórmula guardada correctamente.")
-                    st.image(qr_img, caption="Código QR para esta fórmula", use_container_width=False)
-                    st.code(url_formula, language="markdown")
+    # Opción "Formular" por defecto
+    flujo_crear_formula()
 
 if __name__ == "__main__":
     main()

--- a/crud_formulas/delete_formula.py
+++ b/crud_formulas/delete_formula.py
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------
+# FORMULATOR – Uso exclusivo de Iván Navarro
+# Todos los derechos reservados © 2025
+# Este archivo forma parte de un software no libre y no está autorizado su uso
+# ni distribución sin consentimiento expreso y por escrito del autor.
+# ------------------------------------------------------------------------------
+
+import streamlit as st
+from utils.supabase_client import supabase
+from crud_formulas.list_formulas import listar_formulas
+
+
+def eliminar_formula():
+    st.subheader("🗑️ Eliminar fórmula")
+    formula_id = listar_formulas(seleccionar=True)
+    if not formula_id:
+        return
+
+    confirmar = st.checkbox("Confirmo que deseo eliminar esta fórmula")
+    if st.button("Eliminar"):
+        if confirmar:
+            try:
+                supabase.table("formulas").delete().eq("id", formula_id).execute()
+                st.success("Fórmula eliminada correctamente.")
+                st.experimental_rerun()
+            except Exception as e:
+                st.error(f"❌ Error al eliminar: {e}")
+        else:
+            st.warning("Debes confirmar antes de eliminar.")

--- a/crud_formulas/list_formulas.py
+++ b/crud_formulas/list_formulas.py
@@ -1,0 +1,41 @@
+# ------------------------------------------------------------------------------
+# FORMULATOR – Uso exclusivo de Iván Navarro
+# Todos los derechos reservados © 2025
+# Este archivo forma parte de un software no libre y no está autorizado su uso
+# ni distribución sin consentimiento expreso y por escrito del autor.
+# ------------------------------------------------------------------------------
+
+import streamlit as st
+import pandas as pd
+from utils.supabase_client import supabase
+
+
+def listar_formulas(seleccionar: bool = True):
+    """Muestra las fórmulas guardadas y opcionalmente permite seleccionar una."""
+    st.subheader("📂 Fórmulas disponibles")
+    try:
+        response = supabase.table("formulas").select("id,nombre").execute()
+        df = pd.DataFrame(response.data)
+    except Exception as e:
+        st.error(f"❌ Error al cargar las fórmulas: {e}")
+        return None
+
+    if df.empty:
+        st.info("No hay fórmulas guardadas.")
+        return None
+
+    if seleccionar:
+        opciones = [""] + df["nombre"].tolist()
+        seleccion = st.selectbox(
+            "Selecciona una fórmula",
+            opciones,
+            index=0,
+            key="seleccionar_formula",
+        )
+        if seleccion:
+            formula_id = df[df["nombre"] == seleccion]["id"].iloc[0]
+            return formula_id
+        return None
+    else:
+        st.dataframe(df)
+        return None

--- a/crud_formulas/update_formula.py
+++ b/crud_formulas/update_formula.py
@@ -1,0 +1,85 @@
+# ------------------------------------------------------------------------------
+# FORMULATOR – Uso exclusivo de Iván Navarro
+# Todos los derechos reservados © 2025
+# Este archivo forma parte de un software no libre y no está autorizado su uso
+# ni distribución sin consentimiento expreso y por escrito del autor.
+# ------------------------------------------------------------------------------
+
+import json
+import pandas as pd
+import streamlit as st
+from utils.supabase_client import supabase
+from utils.editor import mostrar_editor_formula
+from utils.families import obtener_familias_parametros
+from utils.formula_resultados import calcular_resultado_formula
+
+
+def actualizar_formula(formula_id: str):
+    """Carga una fórmula existente y permite editarla."""
+    if not formula_id:
+        st.info("Selecciona una fórmula para actualizar.")
+        return
+
+    try:
+        resp = (
+            supabase.table("formulas")
+            .select("*")
+            .eq("id", formula_id)
+            .single()
+            .execute()
+        )
+        data = resp.data
+    except Exception as e:
+        st.error(f"❌ Error al cargar la fórmula: {e}")
+        return
+
+    if not data:
+        st.error("No se encontró la fórmula solicitada.")
+        return
+
+    nombre = st.text_input("Nombre de la fórmula", value=data.get("nombre", ""))
+
+    try:
+        response_mp = supabase.table("materias_primas").select("*").execute()
+        df_mp = pd.DataFrame(response_mp.data)
+        df_mp["%"] = 0.0
+    except Exception as e:
+        st.error(f"❌ Error al cargar materias primas: {e}")
+        return
+
+    actuales = pd.DataFrame(json.loads(data["materias_primas"]))
+    for _, row in actuales.iterrows():
+        mask = df_mp["Materia Prima"] == row["Materia Prima"]
+        if mask.any():
+            df_mp.loc[mask, "%"] = row["%"]
+
+    seleccionadas = st.multiselect(
+        "Materias primas",
+        df_mp["Materia Prima"].tolist(),
+        default=actuales["Materia Prima"].tolist(),
+        key="mp_actualizar",
+    )
+
+    if not seleccionadas:
+        st.warning("Selecciona al menos una materia prima.")
+        return
+
+    df_editado, total_pct = mostrar_editor_formula(df_mp, seleccionadas)
+
+    if df_editado is None:
+        return
+
+    familias = obtener_familias_parametros()
+    columnas = [col for fam in familias.values() for col in fam]
+
+    if st.button("Guardar cambios"):
+        try:
+            precio, _ = calcular_resultado_formula(df_editado, columnas)
+            supabase.table("formulas").update({
+                "nombre": nombre,
+                "materias_primas": json.dumps(df_editado.to_dict(orient="records")),
+                "precio_total": round(precio, 2),
+            }).eq("id", formula_id).execute()
+            st.success("Fórmula actualizada correctamente.")
+        except Exception as e:
+            st.error(f"❌ Error al actualizar: {e}")


### PR DESCRIPTION
## Summary
- add CRUD helpers for formulas
- expose formulas section in the sidebar
- refactor formula creation flow
- enable update and delete of saved formulas

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686cc45a3ff08333b78e8a27555d61ea