### PR TITLE
Remove redundant df_editado check

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,9 +48,6 @@ def flujo_crear_formula():
     st.subheader("🧪 Fórmula editable")
     df_editado, total_pct = mostrar_editor_formula(df, seleccionadas)
 
-    if df_editado is None:
-        return
-
     filtrar_ceros = st.checkbox("Mostrar solo parámetros con cantidad > 0%", value=True)
 
     familias = obtener_familias_parametros()


### PR DESCRIPTION
## Summary
- remove early return when `df_editado` is `None` in `flujo_crear_formula`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_686cdf223aec83338f0356aa1177c0e4