### PR TITLE
Add ZPL label download in formula view

### DIFF
--- a/utils/cargar_formula.py
+++ b/utils/cargar_formula.py
@@ -10,6 +10,7 @@ import pandas as pd
 import json
 from utils.supabase_client import supabase
 from utils.formula_resultados import calcular_resultado_formula
+from utils.generar_etiqueta_zpl import generar_etiqueta_zpl
 
 def cargar_formula_por_id(formula_id: str):
     """
@@ -30,10 +31,13 @@ def cargar_formula_por_id(formula_id: str):
 
         nombre = data["nombre"]
         precio = data["precio_total"]
+        fecha = data.get("fecha_creacion", "")
         materias_primas = pd.DataFrame(json.loads(data["materias_primas"]))
 
         st.markdown(f"### 🧪 **{nombre}**")
         st.markdown(f"**💰 Precio por kg:** {precio:.2f} €")
+        if fecha:
+            st.markdown(f"**📅 Fecha de creación:** {fecha.split('T')[0]}")
 
         # 🔒 Reordenar y renombrar columna % para mejor visualización
         materias_vista = materias_primas.copy()
@@ -57,5 +61,14 @@ def cargar_formula_por_id(formula_id: str):
             st.markdown(composicion_formateada.to_html(index=False), unsafe_allow_html=True)
         else:
             st.info("No hay parámetros significativos en la fórmula.")
+
+        url_formula = f"https://formulator-pruebas2.streamlit.app/?formula_id={formula_id}"
+        zpl_code = generar_etiqueta_zpl(nombre, fecha.split('T')[0] if fecha else '', url_formula)
+        st.download_button(
+            "Descargar etiqueta ZPL",
+            zpl_code,
+            file_name="etiqueta.zpl",
+            mime="text/plain",
+        )
     except Exception as e:
         st.error(f"⚠️ Error al cargar la fórmula: {e}")

--- a/utils/generar_etiqueta_zpl.py
+++ b/utils/generar_etiqueta_zpl.py
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------------
+# FORMULATOR – Uso exclusivo de Iván Navarro
+# Todos los derechos reservados © 2025
+# Este archivo forma parte de un software no libre y no está autorizado su uso
+# ni distribución sin consentimiento expreso y por escrito del autor.
+# ------------------------------------------------------------------------------
+
+"""Funciones para generar etiquetas en formato ZPL para impresoras Zebra."""
+
+
+def generar_etiqueta_zpl(nombre_formula: str, fecha: str, url: str) -> str:
+    """Devuelve el contenido ZPL para una etiqueta.
+
+    La etiqueta incluye el nombre de la fórmula, la fecha de creación y un
+    código QR que apunta a la URL proporcionada.
+    """
+    zpl = f"""
+^XA
+^CF0,40
+^FO20,20^FD{nombre_formula}^FS
+^CF0,25
+^FO20,70^FD{fecha}^FS
+^FO20,110^BQN,2,6^FDLA,{url}^FS
+^XZ
+"""
+    return zpl


### PR DESCRIPTION
## Summary
- add `generar_etiqueta_zpl` helper to build ZPL labels
- show creation date on formula viewer
- provide download button for ZPL label when viewing a formula

## Testing
- `python -m py_compile utils/generar_etiqueta_zpl.py utils/cargar_formula.py`


------
https://chatgpt.com/codex/tasks/task_b_686ce78255048333ad33eeca93296b6d