### PR TITLE
Fix row drag order updates

### DIFF
--- a/utils/editor.py
+++ b/utils/editor.py
@@ -42,11 +42,12 @@ def mostrar_editor_formula(df, seleccionadas):
         df_filtrado,
         gridOptions=grid_options,
         update_mode=GridUpdateMode.MODEL_CHANGED,
+        update_on=["rowDragEnd"],
         fit_columns_on_grid_load=False,
         height=300,
         allow_unsafe_jscode=True,
         theme="streamlit",
-        enable_enterprise_modules=False
+        enable_enterprise_modules=False,
     )
 
     df_editado = grid_response["data"].copy()


### PR DESCRIPTION
## Summary
- refresh AgGrid when rows are dragged to ensure order is persisted
- keep current formula rows when modifying the selection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_686ce6de94e08333bb5d73ec901e00ab